### PR TITLE
Move user validation to registration step to catch errors before send…

### DIFF
--- a/server/src/controllers/userRegister.js
+++ b/server/src/controllers/userRegister.js
@@ -1,6 +1,6 @@
 import sendEmail from "../util/mailer.js";
 import generateCode from "../util/codeGenerator.js";
-import User from "../models/User.js";
+import User, { validateUser } from "../models/User.js";
 import PendingUser from "../models/PendingUser.js";
 import bcrypt from "bcrypt";
 import { logError } from "../util/logging.js";
@@ -25,6 +25,22 @@ export const userRegister = async (req, res) => {
     }
 
     const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
+
+    const userData = {
+      email,
+      username,
+      profile: {
+        first_name: firstName,
+        last_name: lastName,
+      },
+      password: hashedPassword,
+    };
+
+    const validationErrors = validateUser(userData);
+    if (validationErrors.length > 0) {
+      return res.status(400).json({ errors: validationErrors });
+    }
+
     const verificationCode = generateCode();
 
     await PendingUser.deleteOne({ email });

--- a/server/src/controllers/userVerifyEmail.js
+++ b/server/src/controllers/userVerifyEmail.js
@@ -1,9 +1,10 @@
 import PendingUser from "../models/PendingUser.js";
-import User, { validateUser } from "../models/User.js";
+import User from "../models/User.js";
 import { logError } from "../util/logging.js";
 
 export const verifyEmail = async (req, res) => {
   const { email, verificationCode } = req.body;
+
   if (!email || !verificationCode) {
     return res
       .status(400)
@@ -32,11 +33,6 @@ export const verifyEmail = async (req, res) => {
       },
       password: pending.password,
     };
-    // Validate user data
-    const validationErrors = validateUser(userData);
-    if (validationErrors.length > 0) {
-      return res.status(400).json({ errors: validationErrors });
-    }
 
     const newUser = new User(userData);
     await newUser.save();


### PR DESCRIPTION
- Moved _validateUser_ logic from /verify to /register controller.
- Removed redundant validation from the _verifyEmail_ handler.
- Improved _validateUser_ to check for required fields and disallow unexpected keys via _validateAllowedFields._

This change improves user experience by providing immediate feedback on invalid input, and prevents saving or emailing users with invalid data.

