### PR TITLE
Add request body validation middleware for register, login, and email…

### DIFF
--- a/server/src/controllers/userVerifyEmail.js
+++ b/server/src/controllers/userVerifyEmail.js
@@ -5,12 +5,6 @@ import { logError } from "../util/logging.js";
 export const verifyEmail = async (req, res) => {
   const { email, verificationCode } = req.body;
 
-  if (!email || !verificationCode) {
-    return res
-      .status(400)
-      .json({ error: "Email and verification code are required" });
-  }
-
   try {
     const pending = await PendingUser.findOne({ email });
 

--- a/server/src/middleware/validateLoginBody.js
+++ b/server/src/middleware/validateLoginBody.js
@@ -1,0 +1,20 @@
+const validateLoginBody = (req, res, next) => {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    return res.status(400).json({ error: "Email and password are required" });
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return res.status(400).json({ error: "Invalid email format" });
+  }
+
+  if (typeof password !== "string" || password.trim() === "") {
+    return res.status(400).json({ error: "Password cannot be empty" });
+  }
+
+  next();
+};
+
+export default validateLoginBody;

--- a/server/src/middleware/validateRegisterBody.js
+++ b/server/src/middleware/validateRegisterBody.js
@@ -1,0 +1,34 @@
+const validateRegisterBody = (req, res, next) => {
+  const { email, firstName, lastName, password } = req.body;
+
+  if (!email) {
+    return res.status(400).json({ error: "Email is required" });
+  }
+
+  if (!firstName) {
+    return res.status(400).json({ error: "First name is required" });
+  }
+
+  if (!lastName) {
+    return res.status(400).json({ error: "Last name is required" });
+  }
+
+  if (!password) {
+    return res.status(400).json({ error: "Password is required" });
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return res.status(400).json({ error: "Invalid email format" });
+  }
+
+  if (password.length < 6) {
+    return res
+      .status(400)
+      .json({ error: "Password must be at least 6 characters" });
+  }
+
+  next();
+};
+
+export default validateRegisterBody;

--- a/server/src/middleware/validateVerifyEmailBody.js
+++ b/server/src/middleware/validateVerifyEmailBody.js
@@ -1,0 +1,23 @@
+const validateVerifyEmailBody = (req, res, next) => {
+  const { email, verificationCode } = req.body;
+
+  if (!email || !verificationCode) {
+    return res
+      .status(400)
+      .json({ error: "Email and verification code are required" });
+  }
+
+  if (verificationCode.length !== 6) {
+    return res
+      .status(400)
+      .json({ error: "Verification code must be 6 characters long" });
+  }
+
+  if (typeof verificationCode !== "string" || verificationCode.trim() === "") {
+    return res.status(400).json({ error: "Invalid verification code" });
+  }
+
+  next();
+};
+
+export default validateVerifyEmailBody;

--- a/server/src/routes/login.js
+++ b/server/src/routes/login.js
@@ -1,10 +1,11 @@
 import express from "express";
 import { loginUser } from "../controllers/loginController.js";
 import { logoutUser } from "../controllers/logoutController.js";
+import { validateLoginBody } from "../util/validateBody.js";
 
 const router = express.Router();
 
-router.post("/", loginUser);
+router.post("/", validateLoginBody, loginUser);
 router.post("/logout", logoutUser);
 
 export default router;

--- a/server/src/routes/login.js
+++ b/server/src/routes/login.js
@@ -1,7 +1,7 @@
 import express from "express";
 import { loginUser } from "../controllers/loginController.js";
 import { logoutUser } from "../controllers/logoutController.js";
-import { validateLoginBody } from "../util/validateBody.js";
+import validateLoginBody from "../middleware/validateLoginBody.js";
 
 const router = express.Router();
 

--- a/server/src/routes/register.js
+++ b/server/src/routes/register.js
@@ -1,10 +1,12 @@
 import express from "express";
 import { userRegister } from "../controllers/userRegister.js";
 import { verifyEmail } from "../controllers/userVerifyEmail.js";
+import validateRegisterBody from "../middleware/validateRegisterBody.js";
+import validateVerifyEmailBody from "../middleware/validateVerifyEmailBody.js";
 
 const router = express.Router();
 
-router.post("/", userRegister);
-router.post("/verify", verifyEmail);
+router.post("/", validateRegisterBody, userRegister);
+router.post("/verify", validateVerifyEmailBody, verifyEmail);
 
 export default router;


### PR DESCRIPTION
This pull request adds manual validation middleware for three user-related endpoints:

/register

/login

/verify-email

Each middleware function checks the presence and format of required fields specific to its route.

Changes
Added validateRegisterBody to validate registration requests

Added validateLoginBody to validate login requests

Added validateVerifyEmailBody to validate email verification requests