### PR TITLE
[ FRONTEND ] Clients side for likes

### DIFF
--- a/client/src/components/LikeButton/LikeButton.jsx
+++ b/client/src/components/LikeButton/LikeButton.jsx
@@ -1,17 +1,29 @@
-import { useState } from "react";
+import { useCallback, useState, useEffect } from "react";
 import style from "./LikeButton.module.css";
+import useFetchWithAuth from "../../hooks/useFetchWithAuth.js";
 import PropTypes from "prop-types";
 
 export default function LikeButton({ postId }) {
   const [liked, setLiked] = useState(false);
 
-  const handleToggle = async () => {
-    const res = await fetch(`/api/posts/${postId}/like`, {
-      method: "POST",
-      credentials: "include",
-    });
-    const data = await res.json();
+  const handleStatus = useCallback((data) => {
     setLiked(Boolean(data.liked));
+  }, []);
+  const { performFetch: fetchLikeStatus, cancelFetch } = useFetchWithAuth(
+    `/posts/${postId}/like`,
+    handleStatus,
+  );
+  useEffect(() => {
+    fetchLikeStatus();
+    return () => cancelFetch && cancelFetch();
+  }, [fetchLikeStatus, cancelFetch, postId]);
+
+  const { performFetch: sendLike } = useFetchWithAuth(
+    `/posts/${postId}/like`,
+    (data) => setLiked(Boolean(data.liked)),
+  );
+  const handleToggle = () => {
+    sendLike({ method: "POST", credentials: "include" });
   };
 
   return (
@@ -35,7 +47,7 @@ export default function LikeButton({ postId }) {
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
-            fill={liked ? "currentColor" : "none"}
+            fill={liked ? "#FE4A22" : "none"}
           />
         </g>
       </svg>

--- a/client/src/components/LikeButton/LikeButton.jsx
+++ b/client/src/components/LikeButton/LikeButton.jsx
@@ -1,13 +1,25 @@
+import { useState } from "react";
 import style from "./LikeButton.module.css";
 import PropTypes from "prop-types";
 
-export default function LikeButton({ liked, onClick }) {
+export default function LikeButton({ postId }) {
+  const [liked, setLiked] = useState(false);
+
+  const handleToggle = async () => {
+    const res = await fetch(`/api/posts/${postId}/like`, {
+      method: "POST",
+      credentials: "include",
+    });
+    const data = await res.json();
+    setLiked(Boolean(data.liked));
+  };
+
   return (
     <button
       type="button"
       aria-pressed={liked}
       className={style.likeButton}
-      onClick={onClick}
+      onClick={handleToggle}
       title={liked ? "Unlike" : "Like"}
     >
       <svg
@@ -32,6 +44,5 @@ export default function LikeButton({ liked, onClick }) {
 }
 
 LikeButton.propTypes = {
-  liked: PropTypes.bool.isRequired,
-  onClick: PropTypes.func.isRequired,
+  postId: PropTypes.string.isRequired,
 };

--- a/client/src/components/LikeButton/LikeButton.jsx
+++ b/client/src/components/LikeButton/LikeButton.jsx
@@ -1,0 +1,37 @@
+import style from "./LikeButton.module.css";
+import PropTypes from "prop-types";
+
+export default function LikeButton({ liked, onClick }) {
+  return (
+    <button
+      type="button"
+      aria-pressed={liked}
+      className={style.likeButton}
+      onClick={onClick}
+      title={liked ? "Unlike" : "Like"}
+    >
+      <svg
+        className={style.icon}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M12 7.69431C10 2.99988 3 3.49988 3 9.49991C3 15.4999 12 20.5001 12 20.5001C12 20.5001 21 15.4999 21 9.49991C21 3.49988 14 2.99988 12 7.69431Z"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill={liked ? "currentColor" : "none"}
+          />
+        </g>
+      </svg>
+    </button>
+  );
+}
+
+LikeButton.propTypes = {
+  liked: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+};

--- a/client/src/components/LikeButton/LikeButton.module.css
+++ b/client/src/components/LikeButton/LikeButton.module.css
@@ -1,0 +1,24 @@
+.likeButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  display: inline-flex;
+  align-items: center;
+  transition: filter 0.2s;
+}
+.likeButton:focus {
+  outline: 2px solid #1976d2;
+}
+.likeButton:hover svg {
+  filter: brightness(1.2);
+}
+.icon {
+  width: 24px;
+  height: 24px;
+  display: block;
+}
+
+.likeButton[aria-pressed="true"] {
+  color: #fe4a22;
+}

--- a/client/src/components/LikeButton/LikeButton.module.css
+++ b/client/src/components/LikeButton/LikeButton.module.css
@@ -2,23 +2,21 @@
   background: none;
   border: none;
   cursor: pointer;
-  padding: 4px;
+  padding: 0.25rem;
   display: inline-flex;
   align-items: center;
   transition: filter 0.2s;
 }
-.likeButton:focus {
-  outline: 2px solid #1976d2;
-}
+
 .likeButton:hover svg {
   filter: brightness(1.2);
 }
 .icon {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
   display: block;
 }
 
 .likeButton[aria-pressed="true"] {
-  color: #fe4a22;
+  color: var(--color-orange);
 }

--- a/client/src/components/Post/Post.jsx
+++ b/client/src/components/Post/Post.jsx
@@ -4,7 +4,7 @@ import style from "./Post.module.css";
 import PropTypes from "prop-types";
 import timeAgoCalc from "../../util/timeAgoCalc.js";
 
-function Post({ post, liked, onLikeToggle }) {
+function Post({ post }) {
   const publishedAgo = timeAgoCalc(new Date(post.published_at));
   console.log(publishedAgo);
 
@@ -22,7 +22,7 @@ function Post({ post, liked, onLikeToggle }) {
         </header>
         <p className={style.postContent}>{post.content}</p>
       </section>
-      <PostFooter tags={post.tags} liked={liked} onLikeToggle={onLikeToggle} />
+      <PostFooter postId={post._id} tags={post.tags} />
     </article>
   );
 }

--- a/client/src/components/Post/Post.jsx
+++ b/client/src/components/Post/Post.jsx
@@ -4,7 +4,7 @@ import style from "./Post.module.css";
 import PropTypes from "prop-types";
 import timeAgoCalc from "../../util/timeAgoCalc.js";
 
-function Post({ post }) {
+function Post({ post, liked, onLikeToggle }) {
   const publishedAgo = timeAgoCalc(new Date(post.published_at));
   console.log(publishedAgo);
 
@@ -22,7 +22,7 @@ function Post({ post }) {
         </header>
         <p className={style.postContent}>{post.content}</p>
       </section>
-      <PostFooter tags={post.tags} />
+      <PostFooter tags={post.tags} liked={liked} onLikeToggle={onLikeToggle} />
     </article>
   );
 }
@@ -47,3 +47,25 @@ Post.propTypes = {
 };
 
 export default Post;
+
+Post.propTypes = {
+  post: PropTypes.shape({
+    author: PropTypes.shape({
+      _id: PropTypes.string,
+      username: PropTypes.string,
+      email: PropTypes.string,
+    }),
+    content: PropTypes.string,
+    created_at: PropTypes.string,
+    published_at: PropTypes.string,
+    score: PropTypes.number,
+    status: PropTypes.oneOf(["DRAFT", "PUBLISHED", "ARCHIVED"]),
+    tags: PropTypes.arrayOf(PropTypes.string),
+    title: PropTypes.string,
+    __v: PropTypes.number,
+    _id: PropTypes.string,
+    likedByCurrentUser: PropTypes.bool,
+  }).isRequired,
+  liked: PropTypes.bool.isRequired,
+  onLikeToggle: PropTypes.func.isRequired,
+};

--- a/client/src/components/PostFooter/PostFooter.jsx
+++ b/client/src/components/PostFooter/PostFooter.jsx
@@ -82,12 +82,12 @@ const More = () => {
   );
 };
 
-function PostFooter({ tags, liked, onLikeToggle }) {
+function PostFooter({ postId, tags }) {
   return (
     <footer className={style.footer}>
       <section className={style.wrapper}>
         <section className={style.actionsContainer}>
-          <LikeButton liked={liked} onClick={onLikeToggle} />
+          <LikeButton postId={postId} />
           <Button icon={<Comment />} />
           <Button icon={<Share />} />
         </section>
@@ -111,11 +111,10 @@ function PostFooter({ tags, liked, onLikeToggle }) {
 
 PostFooter.propTypes = {
   tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+  postId: PropTypes.string.isRequired,
 };
 
 export default PostFooter;
 PostFooter.propTypes = {
   tags: PropTypes.arrayOf(PropTypes.string).isRequired,
-  liked: PropTypes.bool.isRequired,
-  onLikeToggle: PropTypes.func.isRequired,
 };

--- a/client/src/components/PostFooter/PostFooter.jsx
+++ b/client/src/components/PostFooter/PostFooter.jsx
@@ -1,29 +1,8 @@
 import Button from "../Button.jsx";
 import style from "./PostFooter.module.css";
 import PropTypes from "prop-types";
+import LikeButton from "../LikeButton/LikeButton.jsx";
 
-const Like = ({ fill = false }) => {
-  return (
-    <svg
-      className={style.icon}
-      viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g id="Interface / Heart_01">
-        <path
-          id="Vector"
-          d="M12 7.69431C10 2.99988 3 3.49988 3 9.49991C3 15.4999 12 20.5001 12 20.5001C12 20.5001 21 15.4999 21 9.49991C21 3.49988 14 2.99988 12 7.69431Z"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          fill={fill ? "currentColor" : "none"}
-        />
-      </g>
-    </svg>
-  );
-};
 const Comment = () => {
   return (
     <svg
@@ -103,12 +82,12 @@ const More = () => {
   );
 };
 
-function PostFooter({ tags }) {
+function PostFooter({ tags, liked, onLikeToggle }) {
   return (
     <footer className={style.footer}>
       <section className={style.wrapper}>
         <section className={style.actionsContainer}>
-          <Button icon={<Like fill={false} />} />
+          <LikeButton liked={liked} onClick={onLikeToggle} />
           <Button icon={<Comment />} />
           <Button icon={<Share />} />
         </section>
@@ -134,8 +113,9 @@ PostFooter.propTypes = {
   tags: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
-Like.propTypes = {
-  fill: PropTypes.bool,
-};
-
 export default PostFooter;
+PostFooter.propTypes = {
+  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+  liked: PropTypes.bool.isRequired,
+  onLikeToggle: PropTypes.func.isRequired,
+};

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,19 +1,4 @@
 function Home() {
-  // This is the management of likes on Feed. It should be uncommented when the feed is ready
-  // const [posts, setPosts] = useState([]);
-
-  // const handleLikeToggle = async (postId) => {
-  //   const res = await fetch(`/api/posts/${postId}/like`, { method: "POST", credentials: "include" });
-  //   const data = await res.json();
-  //   setPosts(posts =>
-  //     posts.map(post =>
-  //       post._id === postId
-  //         ? { ...post, likedByCurrentUser: data.liked }
-  //         : post
-  //     )
-  //   );
-  // };
-
   return <>Home Page</>;
 }
 

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,4 +1,19 @@
 function Home() {
+  // This is the management of likes on Feed. It should be uncommented when the feed is ready
+  // const [posts, setPosts] = useState([]);
+
+  // const handleLikeToggle = async (postId) => {
+  //   const res = await fetch(`/api/posts/${postId}/like`, { method: "POST", credentials: "include" });
+  //   const data = await res.json();
+  //   setPosts(posts =>
+  //     posts.map(post =>
+  //       post._id === postId
+  //         ? { ...post, likedByCurrentUser: data.liked }
+  //         : post
+  //     )
+  //   );
+  // };
+
   return <>Home Page</>;
 }
 

--- a/client/src/pages/Post/Post.jsx
+++ b/client/src/pages/Post/Post.jsx
@@ -23,11 +23,28 @@ export default function PostPage() {
     return () => {
       cancelFetch && cancelFetch();
     };
-  }, []);
+  }, [id]);
+
+  // Like switcher function
+  const handleLikeToggle = async () => {
+    if (!post) return;
+    const res = await fetch(`/api/posts/${post._id}/like`, {
+      method: "POST",
+      credentials: "include",
+    });
+    const data = await res.json();
+    setPost((prev) => ({ ...prev, likedByCurrentUser: data.liked }));
+  };
 
   if (isLoading && !post) return <div>Loading…</div>;
   if (error) return <div>Error: {String(error.message || error)}</div>;
   if (!post) return null;
 
-  return <Post post={post} />;
+  return (
+    <Post
+      post={post}
+      liked={post.likedByCurrentUser}
+      onLikeToggle={handleLikeToggle}
+    />
+  );
 }

--- a/client/src/pages/Post/Post.jsx
+++ b/client/src/pages/Post/Post.jsx
@@ -25,26 +25,9 @@ export default function PostPage() {
     };
   }, [id]);
 
-  // Like switcher function
-  const handleLikeToggle = async () => {
-    if (!post) return;
-    const res = await fetch(`/api/posts/${post._id}/like`, {
-      method: "POST",
-      credentials: "include",
-    });
-    const data = await res.json();
-    setPost((prev) => ({ ...prev, likedByCurrentUser: data.liked }));
-  };
-
   if (isLoading && !post) return <div>Loading…</div>;
   if (error) return <div>Error: {String(error.message || error)}</div>;
   if (!post) return null;
 
-  return (
-    <Post
-      post={post}
-      liked={post.likedByCurrentUser}
-      onLikeToggle={handleLikeToggle}
-    />
-  );
+  return <Post post={post} />;
 }

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,7 +1,7 @@
 import ProfileDash from "../components/ProfileDash/ProfileDash.jsx";
 import { useContext } from "react";
 import UserDataContext from "../context/userDataContext/UserDataContext.js";
-import Post from "../components/Post/Post.jsx";
+// import Post from "../components/Post/Post.jsx";
 
 function Profile() {
   const { userData } = useContext(UserDataContext);
@@ -13,7 +13,7 @@ function Profile() {
   return (
     <>
       <ProfileDash size="lg" user={userData} followBtn={false} />
-      <Post />
+      {/* <Post /> <--- this can creates an error and crashes the server because we do not forward the required props. Later we will have more props here. Example, Post({ post, liked, onLikeToggle }) */}
     </>
   );
 }


### PR DESCRIPTION
- Added a LikeButton component that shows a heart icon and supports toggling likes on click.
**The logic behind it is next: first click add Like, second - with remove this Like, the next one will put it again, etc.**

- Passed the liked state and onLikeToggle handler down from the post page to the Post and PostFooter components, ensuring each post “knows” its like status.
- Handled the like API request in the page component, updating the liked state based on the backend response.
- Used CSS to change the heart color to orange (#FE4A22) when a post is liked, by targeting the button’s aria-pressed attribute.

- (!) added  Like functionaslity to the Home page, but commited in order not to brock it
- (!) Found problem Post component on Profile page - with out props.  I think it is already updated in next PRs. 