### PR TITLE
[ BACKEND ] - Edit Post endpoint updated

### DIFF
--- a/server/src/controllers/postController.js
+++ b/server/src/controllers/postController.js
@@ -80,12 +80,14 @@ export const createPost = async (req, res) => {
 export const updatePost = async (req, res) => {
   try {
     const post = await Post.findById(req.params.id);
-    if (!post) return res.status(404).json({ message: "Post not found" });
+    if (!post) {
+      return res.status(404).json({ success: false, msg: "Post not found" });
+    }
 
     if (post.author.toString() !== req.user._id.toString()) {
       return res
         .status(403)
-        .json({ message: "Not authorized to update this post" });
+        .json({ success: false, msg: "Not authorized to update this post" });
     }
 
     // Allowed fields
@@ -97,13 +99,24 @@ export const updatePost = async (req, res) => {
       }
     }
 
-    // if the status is PUBLISHED - update the date
     const statusTo = updates.status ?? post.status;
+
+    // Update published_at only if the status changes
     if (statusTo === "PUBLISHED") {
       updates.published_at = new Date();
-    } else {
-      // If it leaves the publication - reset published_at (if you want)
+    } else if (post.status === "PUBLISHED" && statusTo !== "PUBLISHED") {
+      // Only reset published_at if transitioning from PUBLISHED to a non-published status
       updates.published_at = null;
+    }
+
+    // Prepare candidate for validation
+    const candidate = { ...post.toObject(), ...updates };
+    const errors = validatePost(candidate);
+    if (errors.length) {
+      return res.status(400).json({
+        success: false,
+        msg: errors.join("; "),
+      });
     }
 
     const updatedPost = await Post.findByIdAndUpdate(req.params.id, updates, {
@@ -111,9 +124,15 @@ export const updatePost = async (req, res) => {
       runValidators: true,
     });
 
-    res.json(updatedPost);
+    if (!updatedPost) {
+      return res
+        .status(404)
+        .json({ success: false, msg: "Post not found after update" });
+    }
+
+    res.json({ success: true, post: updatedPost });
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(400).json({ success: false, msg: error.message });
   }
 };
 

--- a/server/src/controllers/postController.js
+++ b/server/src/controllers/postController.js
@@ -82,14 +82,31 @@ export const updatePost = async (req, res) => {
     const post = await Post.findById(req.params.id);
     if (!post) return res.status(404).json({ message: "Post not found" });
 
-    // Check that only the author can edit
     if (post.author.toString() !== req.user._id.toString()) {
       return res
         .status(403)
         .json({ message: "Not authorized to update this post" });
     }
 
-    const updatedPost = await Post.findByIdAndUpdate(req.params.id, req.body, {
+    // Allowed fields
+    const allowedFields = ["title", "content", "tags", "status"];
+    const updates = {};
+    for (const field of allowedFields) {
+      if (req.body[field] !== undefined) {
+        updates[field] = req.body[field];
+      }
+    }
+
+    // if the status is PUBLISHED - update the date
+    const statusTo = updates.status ?? post.status;
+    if (statusTo === "PUBLISHED") {
+      updates.published_at = new Date();
+    } else {
+      // If it leaves the publication - reset published_at (if you want)
+      updates.published_at = null;
+    }
+
+    const updatedPost = await Post.findByIdAndUpdate(req.params.id, updates, {
       new: true,
       runValidators: true,
     });


### PR DESCRIPTION
<img width="550" height="245" alt="2025-08-19 08_43_07-MongoDB Compass - hyf-final-projects cwlgq mongodb net_c52-group-a posts" src="https://github.com/user-attachments/assets/0e94c779-68c7-4d83-880e-09f8ed3f4d2b" />

Summary: 
- Check previous eImplementationof  the post editing endpoint. It still use  PATCH /api/post/:id with author verification, 
- Not add fields from DB are allowed for user to edit;
- Added automatic update of the publication date. When a post is set to or remains in "PUBLISHED" status, the published_at field is automatically updated to the current date and time on every change.