### PR TITLE
[FRONTEND] UI Creating post

### DIFF
--- a/client/src/components/CreatePostForm/CreatePostForm.jsx
+++ b/client/src/components/CreatePostForm/CreatePostForm.jsx
@@ -31,7 +31,7 @@ export default function CreatePostForm({ onCreated }) {
       body: JSON.stringify({
         title: title.trim(),
         content: content.trim(),
-        status,
+        status: status ?? "DRAFT",
         tags: tagsInput
           .split(",")
           .map((t) => t.trim())

--- a/client/src/components/CreatePostForm/CreatePostForm.jsx
+++ b/client/src/components/CreatePostForm/CreatePostForm.jsx
@@ -2,12 +2,16 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import useFetchWithAuth from "../../hooks/useFetchWithAuth";
 import Button from "../Button.jsx";
+import InputField from "../InputField/InputField.jsx";
+import style from "./CreatePostForm.module.css";
+import TextArea from "../TextArea/TextArea.jsx";
+import Drawer from "../Drawer/Drawer.jsx";
 
 export default function CreatePostForm({ onCreated }) {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [tagsInput, setTagsInput] = useState("");
-  const [status, setStatus] = useState("DRAFT");
+  const [status, setStatus] = useState("");
 
   const { isLoading, error, performFetch } = useFetchWithAuth(
     "/post",
@@ -37,61 +41,49 @@ export default function CreatePostForm({ onCreated }) {
   };
 
   return (
-    <form onSubmit={onSubmit} className="space-y-3 max-w-xl">
-      <label>
-        Title*
-        <input
-          className="w-full border p-2"
+    <main className={style.main}>
+      <form onSubmit={onSubmit} className={style.form}>
+        <InputField
+          name="title"
+          placeholder="Title*"
+          type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           required
         />
-      </label>
 
-      <label>
-        Content*
-        <textarea
-          className="w-full border p-2"
-          rows={8}
+        <TextArea
+          name="content"
+          placeholder="Content*"
           value={content}
           onChange={(e) => setContent(e.target.value)}
           required
         />
-      </label>
 
-      <div className="grid grid-cols-2 gap-3">
-        <label>
-          Post status
-          <select
-            className="w-full border p-2"
+        <div className={style.optionsContainer}>
+          <Drawer
+            name="status"
             value={status}
+            options={["DRAFT", "PUBLISHED"]}
+            placeholder="Select status"
             onChange={(e) => setStatus(e.target.value)}
-          >
-            <option value="DRAFT">DRAFT</option>
-            <option value="PUBLISHED">PUBLISHED</option>
-          </select>
-        </label>
-
-        <label>
-          Gegs (Separated by commas)
-          <input
-            className="w-full border p-2"
+          />
+          <InputField
+            name="tags"
+            type="text"
+            placeholder="Tags (comma-separated)"
             value={tagsInput}
             onChange={(e) => setTagsInput(e.target.value)}
           />
-        </label>
-      </div>
+        </div>
 
-      {error && <p style={{ color: "red" }}>{String(error)}</p>}
+        {error && <p style={{ color: "red" }}>{String(error)}</p>}
 
-      <Button
-        type="submit"
-        disabled={isLoading}
-        className="px-4 py-2 bg-black text-white rounded"
-      >
-        {isLoading ? "Saving..." : "Create"}
-      </Button>
-    </form>
+        <Button type="submit" disabled={isLoading} className={style.submitBtn}>
+          {isLoading ? "Saving..." : "Create"}
+        </Button>
+      </form>
+    </main>
   );
 }
 

--- a/client/src/components/CreatePostForm/CreatePostForm.module.css
+++ b/client/src/components/CreatePostForm/CreatePostForm.module.css
@@ -33,7 +33,4 @@
     box-shadow: none;
     margin-bottom: 10vw;
   }
-  .signInContainer {
-    padding: 2rem 2rem 1rem 2rem;
-  }
 }

--- a/client/src/components/CreatePostForm/CreatePostForm.module.css
+++ b/client/src/components/CreatePostForm/CreatePostForm.module.css
@@ -1,0 +1,39 @@
+.main {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--outer-border-radius);
+  padding: 2.5rem;
+  box-shadow: 0 0 10px var(--color-border);
+}
+.optionsContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+}
+.submitBtn {
+  background: var(--color-dark-grey);
+  color: var(--color-white);
+  border-radius: var(--inner-border-radius);
+  padding: 1rem;
+  margin: 0.5rem 3rem;
+}
+
+@media (max-width: 768px) {
+  .form {
+    border: none;
+    box-shadow: none;
+    margin-bottom: 10vw;
+  }
+  .signInContainer {
+    padding: 2rem 2rem 1rem 2rem;
+  }
+}

--- a/client/src/components/Drawer/Drawer.jsx
+++ b/client/src/components/Drawer/Drawer.jsx
@@ -1,0 +1,34 @@
+import PropTypes from "prop-types";
+import style from "./Drawer.module.css";
+
+function Drawer({ name, value, options, placeholder, onChange }) {
+  return (
+    <label htmlFor={name} className={style.label}>
+      <select
+        id={name}
+        name={name}
+        value={value}
+        onChange={onChange}
+        className={style.input}
+      >
+        <option value="">{placeholder}</option>
+        {options.length > 0 &&
+          options.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+      </select>
+    </label>
+  );
+}
+
+Drawer.propTypes = {
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  placeholder: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default Drawer;

--- a/client/src/components/Drawer/Drawer.jsx
+++ b/client/src/components/Drawer/Drawer.jsx
@@ -3,7 +3,7 @@ import style from "./Drawer.module.css";
 
 function Drawer({ name, value, options, placeholder, onChange }) {
   return (
-    <label htmlFor={name} className={style.label}>
+    <label htmlFor={name}>
       <select
         id={name}
         name={name}
@@ -25,7 +25,7 @@ function Drawer({ name, value, options, placeholder, onChange }) {
 
 Drawer.propTypes = {
   name: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
   placeholder: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/client/src/components/Drawer/Drawer.module.css
+++ b/client/src/components/Drawer/Drawer.module.css
@@ -1,0 +1,8 @@
+.label {
+}
+.input {
+  border: 1px solid var(--color-border);
+  border-radius: var(--pill-border-radius);
+  padding: 0.3rem 0.5rem;
+  transition: border-color 0.2s ease;
+}

--- a/client/src/components/Drawer/Drawer.module.css
+++ b/client/src/components/Drawer/Drawer.module.css
@@ -1,5 +1,3 @@
-.label {
-}
 .input {
   border: 1px solid var(--color-border);
   border-radius: var(--pill-border-radius);

--- a/client/src/components/InputField/InputField.module.css
+++ b/client/src/components/InputField/InputField.module.css
@@ -10,10 +10,6 @@
   font-size: 1rem;
   transition: border-color 0.2s ease;
 }
-.input:focus,
-.input:hover {
-  border-color: var(--color-dark-grey);
-}
 .placeholder {
   position: absolute;
   top: 25%;

--- a/client/src/components/TextArea/TextArea.jsx
+++ b/client/src/components/TextArea/TextArea.jsx
@@ -1,0 +1,29 @@
+import style from "./TextArea.module.css";
+import PropTypes from "prop-types";
+
+function TextArea({ name, placeholder, value, onChange, required }) {
+  return (
+    <label htmlFor={name} className={style.textArea}>
+      <textarea
+        id={name}
+        name={name}
+        rows={10}
+        value={value}
+        onChange={onChange}
+        required={required}
+        className={style.input}
+      />
+      <span className={style.placeholder}>{placeholder}</span>
+    </label>
+  );
+}
+
+TextArea.propTypes = {
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  required: PropTypes.bool,
+};
+
+export default TextArea;

--- a/client/src/components/TextArea/TextArea.module.css
+++ b/client/src/components/TextArea/TextArea.module.css
@@ -1,0 +1,22 @@
+.textArea {
+  display: flex;
+  position: relative;
+}
+.input {
+  flex: 1;
+  padding: 1.3rem 0.8rem 0.5rem 0.8rem;
+  border-radius: var(--inner-border-radius);
+  border: 1px solid var(--color-border);
+  font-size: 1rem;
+  transition: border-color 0.2s ease;
+  resize: none;
+}
+.placeholder {
+  position: absolute;
+  top: 7%;
+  left: 5%;
+  transform: translateY(-50%);
+  color: var(--color-dark-grey);
+  font-size: 0.8rem;
+  pointer-events: none;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -51,12 +51,22 @@ a:hover {
 }
 
 button,
-input {
+input,
+textarea,
+select {
   font-family: inherit;
   font-weight: inherit;
   border: none;
   background: none;
   outline: none;
+}
+input:hover,
+input:focus,
+textarea:hover,
+textarea:focus,
+select:hover,
+select:focus {
+  border-color: var(--color-dark-grey);
 }
 button {
   cursor: pointer;

--- a/client/src/pages/NewPost/NewPost.jsx
+++ b/client/src/pages/NewPost/NewPost.jsx
@@ -1,10 +1,5 @@
 import CreatePostForm from "../../components/CreatePostForm/CreatePostForm.jsx";
 
 export default function NewPostPage() {
-  return (
-    <div className="p-4">
-      <h1>New Post Page</h1>
-      <CreatePostForm onCreated={(post) => console.log("created:", post)} />
-    </div>
-  );
+  return <CreatePostForm onCreated={(post) => console.log("created:", post)} />;
 }


### PR DESCRIPTION
### Summary
This pull request refactors the `CreatePostForm` component to use new reusable UI components (`InputField`, `TextArea`, and `Drawer`) and introduces modular CSS for improved styling and maintainability. It also adds new components for form elements and enhances the global form input experience with consistent focus and hover styles.

**Component Refactoring and UI Improvements:**

* Refactored `CreatePostForm` to use new reusable components (`InputField`, `TextArea`, and `Drawer`) instead of plain HTML elements, improving code readability and consistency. The form layout now uses modular CSS from `CreatePostForm.module.css`. 
* Added new `Drawer` component for select inputs, with associated styles in `Drawer.module.css`. 
* Added new `TextArea` component for multi-line text input, with associated styles in `TextArea.module.css`. 

**Styling Enhancements:**

* Introduced `CreatePostForm.module.css` for modular and responsive form styling, including layout, button, and container classes. 
* Updated global styles in `index.css` to apply consistent font, focus, and hover styles to all inputs, textareas, and selects. 
* Cleaned up `InputField` styles by removing redundant focus/hover rules, now handled globally. 
**Page Structure:**

* Simplified the `NewPostPage` to render only the `CreatePostForm`, removing unnecessary markup. 