### PR TITLE
[FRONTEND] Button for creating a post UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -36,7 +36,7 @@ const App = () => {
         <Route path="/post/:id" element={<PostPage />} />
         <Route path="/post/:id/edit" element={<EditPostPage />} />
       </Routes>
-      {!hideFabOn.includes(location.pathname) && <Fab>Create post</Fab>}
+      {!hideFabOn.includes(location.pathname) && <Fab />}
     </>
   );
 };

--- a/client/src/components/Fab/Fab.jsx
+++ b/client/src/components/Fab/Fab.jsx
@@ -1,10 +1,9 @@
 import { useNavigate } from "react-router-dom";
 import style from "./Fab.module.css";
-import PropTypes from "prop-types";
 import Button from "../Button.jsx";
 import PlusIcon from "../icons/PlusIcon.jsx";
 
-export default function Fab() {
+function Fab() {
   const navigate = useNavigate();
 
   const handleClick = () => {
@@ -18,6 +17,4 @@ export default function Fab() {
   );
 }
 
-Fab.propTypes = {
-  children: PropTypes.node,
-};
+export default Fab;

--- a/client/src/components/Fab/Fab.jsx
+++ b/client/src/components/Fab/Fab.jsx
@@ -1,9 +1,10 @@
 import { useNavigate } from "react-router-dom";
-import styles from "./Fab.module.css";
+import style from "./Fab.module.css";
 import PropTypes from "prop-types";
 import Button from "../Button.jsx";
+import PlusIcon from "../icons/PlusIcon.jsx";
 
-export default function Fab({ children }) {
+export default function Fab() {
   const navigate = useNavigate();
 
   const handleClick = () => {
@@ -11,8 +12,8 @@ export default function Fab({ children }) {
   };
 
   return (
-    <Button className={styles.fab} onClick={handleClick}>
-      {children}
+    <Button className={style.fab} onClick={handleClick}>
+      <PlusIcon style={style.icon} />
     </Button>
   );
 }

--- a/client/src/components/Fab/Fab.module.css
+++ b/client/src/components/Fab/Fab.module.css
@@ -4,12 +4,11 @@
   right: 2rem;
   background: var(--color-orange);
   color: var(--color-white);
-  border: none;
   border-radius: var(--circle-border-radius);
-  padding: 1.6rem 2.3rem 1.6rem 2rem;
-  font-size: 1.5rem;
-  font-weight: 500;
-  font-family: inherit;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  padding: 1rem 1rem 0.813rem 1rem;
   z-index: 1000;
+}
+.icon {
+  width: 2rem;
+  height: 2rem;
 }

--- a/client/src/components/Fab/Fab.module.css
+++ b/client/src/components/Fab/Fab.module.css
@@ -6,7 +6,7 @@
   color: var(--color-white);
   border-radius: var(--circle-border-radius);
   padding: 1rem 1rem 0.813rem 1rem;
-  z-index: 1000;
+  z-index: 999;
 }
 .icon {
   width: 2rem;

--- a/client/src/components/icons/PlusIcon.jsx
+++ b/client/src/components/icons/PlusIcon.jsx
@@ -1,0 +1,29 @@
+import PropTypes from "prop-types";
+
+function PlusIcon({ style }) {
+  return (
+    <svg
+      className={style}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g id="Edit / Add_Plus">
+        <path
+          id="Vector"
+          d="M6 12H12M12 12H18M12 12V18M12 12V6"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </g>
+    </svg>
+  );
+}
+
+PlusIcon.propTypes = {
+  style: PropTypes.string,
+};
+
+export default PlusIcon;


### PR DESCRIPTION
### Summary
This pull request updates the floating action button (FAB) used for creating posts, replacing the text label with a plus icon for a cleaner and more intuitive user interface. The changes also include related styling adjustments and the introduction of a reusable `PlusIcon` component.

**UI/UX Improvements:**

* The `Fab` component now displays a plus icon instead of the "Create post" text, providing a more standard and visually appealing FAB. 
* Added a new reusable `PlusIcon` component for use in the FAB and potentially elsewhere in the application.

**Styling Adjustments:**

* Updated the FAB's CSS to adjust padding and remove unnecessary typography and box-shadow styles, as the button now only contains an icon. Also added a style for the icon's size.

**Code Quality:**

* Fixed a typo in the CSS import within the `Fab` component (`styles` → `style`). 