### PR TITLE
Menu in post footer to  edit or delete post

### DIFF
--- a/client/src/components/DeletePostButton/DeletePostButton.jsx
+++ b/client/src/components/DeletePostButton/DeletePostButton.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import Button from "../Button.jsx";
 import useFetchWithAuth from "../../hooks/useFetchWithAuth";
 
-function DeletePostButton({ postId, onDelete }) {
+function DeletePostButton({ postId, onDelete, className }) {
   const { isLoading, error, performFetch } = useFetchWithAuth(
     `/post/${postId}`,
     () => {
@@ -18,7 +18,11 @@ function DeletePostButton({ postId, onDelete }) {
 
   return (
     <>
-      <Button onClick={handleDelete} disabled={isLoading || !postId}>
+      <Button
+        onClick={handleDelete}
+        className={className}
+        disabled={isLoading || !postId}
+      >
         {isLoading ? "Deleting..." : "Delete"}
       </Button>
       {error && (
@@ -33,6 +37,7 @@ function DeletePostButton({ postId, onDelete }) {
 DeletePostButton.propTypes = {
   postId: PropTypes.string.isRequired,
   onDelete: PropTypes.func,
+  className: PropTypes.string,
 };
 
 export default DeletePostButton;

--- a/client/src/components/EditProfileForm/EditProfileForm.jsx
+++ b/client/src/components/EditProfileForm/EditProfileForm.jsx
@@ -7,6 +7,7 @@ import style from "./EditProfileForm.module.css";
 
 export default function EditProfileForm({ profile, error, onSave, onCancel }) {
   const [form, setForm] = useState({
+    username: profile?.username || "",
     first_name: profile?.first_name || "",
     last_name: profile?.last_name || "",
     bio: profile?.bio || "",
@@ -14,6 +15,7 @@ export default function EditProfileForm({ profile, error, onSave, onCancel }) {
 
   useEffect(() => {
     setForm({
+      username: profile?.username || "",
       first_name: profile?.first_name || "",
       last_name: profile?.last_name || "",
       bio: profile?.bio || "",
@@ -32,6 +34,15 @@ export default function EditProfileForm({ profile, error, onSave, onCancel }) {
 
   return (
     <form className={style.form} onSubmit={handleSubmit}>
+      <InputField
+        name="username"
+        type="text"
+        placeholder="Username"
+        value={form.username}
+        onChange={handleChange}
+        required
+        className={style.input}
+      />
       <InputField
         name="first_name"
         type="text"
@@ -74,6 +85,7 @@ export default function EditProfileForm({ profile, error, onSave, onCancel }) {
 
 EditProfileForm.propTypes = {
   profile: PropTypes.shape({
+    username: PropTypes.string,
     first_name: PropTypes.string,
     last_name: PropTypes.string,
     bio: PropTypes.string,

--- a/client/src/components/Post/Post.jsx
+++ b/client/src/components/Post/Post.jsx
@@ -2,21 +2,20 @@ import ProfileDash from "../ProfileDash/ProfileDash.jsx";
 import PostFooter from "../PostFooter/PostFooter.jsx";
 import style from "./Post.module.css";
 import PropTypes from "prop-types";
-import timeAgoCalc from "../../util/timeAgoCalc.js";
+// import timeAgoCalc from "../../util/timeAgoCalc.js";
 import { useContext } from "react";
 import StateContext from "../../context/state/StateContext.js";
 import { Link, useLocation } from "react-router-dom";
 
 function Post({ post, className, dashboard = true }) {
-  const publishedAgo = timeAgoCalc(new Date(post.published_at));
-  console.log(publishedAgo);
-
+  // const publishedAgo = timeAgoCalc(new Date(post.published_at)); // is assigned a value but never used
   const location = useLocation();
-  const linkDisabled = location.pathname === `/post/${post._id}`;
 
-  // Follow button visibility
   const userData = useContext(StateContext);
   const showFollowBtn = userData?.userId !== post.author._id;
+  const linkDisabled = location.pathname === `/post/${post._id}`;
+
+  console.log("Post -> authorId:", post.author._id);
 
   return (
     <article className={[style.wrapper, className].filter(Boolean).join(" ")}>
@@ -28,6 +27,7 @@ function Post({ post, className, dashboard = true }) {
           user={post.author}
         />
       )}
+
       <Link
         className={linkDisabled ? style.linkDisabled : style.link}
         to={`/post/${post._id}`}
@@ -39,7 +39,11 @@ function Post({ post, className, dashboard = true }) {
           <p className={style.postContent}>{post.content}</p>
         </section>
       </Link>
-      <PostFooter postId={post._id} tags={post.tags} />
+      <PostFooter
+        postId={post._id}
+        tags={post.tags}
+        authorId={post.author._id}
+      />
     </article>
   );
 }

--- a/client/src/components/Post/Post.module.css
+++ b/client/src/components/Post/Post.module.css
@@ -25,3 +25,52 @@
 .linkDisabled:hover {
   text-decoration: none;
 }
+
+.menuWrapper {
+  position: relative;
+  top: 1.5rem;
+  right: 1.5rem;
+  z-index: 12;
+}
+
+.menuBtn {
+  background: none;
+  border: none;
+  font-size: 1.7rem;
+  cursor: pointer;
+  border-radius: 50%;
+  padding: 0.2em 0.5em;
+  transition: background 0.18s;
+}
+.menuBtn:hover,
+.menuBtn:focus {
+  background: #f2f2f2;
+}
+
+.menuPopover {
+  position: absolute;
+  right: 0;
+  top: 2.2rem;
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 0.7rem;
+  box-shadow: 0 2px 12px #0002;
+  z-index: 20;
+  min-width: 140px;
+  list-style: none;
+  padding: 0.5em 0;
+  margin: 0;
+}
+.menuItem {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.6em 1.2em;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.18s;
+}
+.menuItem:hover {
+  background: #ffe494;
+}

--- a/client/src/components/PostFooter/PostFooter.jsx
+++ b/client/src/components/PostFooter/PostFooter.jsx
@@ -1,10 +1,23 @@
+import { useState, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import StateContext from "../../context/state/StateContext.js";
 import Button from "../Button.jsx";
 import style from "./PostFooter.module.css";
 import PropTypes from "prop-types";
 import { CommentIcon, ShareIcon, MoreIcon } from "../icons/index.js";
 import LikeButton from "../LikeButton/LikeButton.jsx";
+import DeletePostButton from "../DeletePostButton/DeletePostButton.jsx";
 
-function PostFooter({ postId, tags }) {
+function PostFooter({ postId, tags, authorId }) {
+  const { state } = useContext(StateContext);
+  const userId = state.userId;
+  console.log("PostFooter userId:", userId);
+  console.log("PostFooter authorId:", authorId);
+  const isAuthor = userId === authorId;
+  console.log("isAuthor:", isAuthor);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const navigate = useNavigate();
+
   return (
     <footer className={style.footer}>
       <section className={style.wrapper}>
@@ -16,17 +29,48 @@ function PostFooter({ postId, tags }) {
         <section className={style.tagsContainer}>
           <ul>
             {tags.length !== 0 &&
-              tags.map((tag) => {
-                return (
-                  <li key={tag} className={style.tag}>
-                    {tag}
-                  </li>
-                );
-              })}
+              tags.map((tag) => (
+                <li key={tag} className={style.tag}>
+                  {tag}
+                </li>
+              ))}
           </ul>
         </section>
       </section>
-      <Button icon={<MoreIcon style={style.icon} />} />
+      {isAuthor && (
+        <div className={style.menuWrapper}>
+          <Button
+            icon={<MoreIcon style={style.icon} />}
+            onClick={() => setMenuOpen((open) => !open)}
+            aria-label="Post actions"
+          />
+          {menuOpen && (
+            <ul className={style.menuPopover}>
+              <li>
+                <button
+                  className={style.menuItem}
+                  onClick={() => {
+                    setMenuOpen(false);
+                    navigate(`/post/${postId}/edit`);
+                  }}
+                >
+                  Edit post
+                </button>
+              </li>
+              <li>
+                <DeletePostButton
+                  postId={postId}
+                  className={style.menuItem}
+                  onDelete={() => {
+                    setMenuOpen(false);
+                    navigate("/home");
+                  }}
+                />
+              </li>
+            </ul>
+          )}
+        </div>
+      )}
     </footer>
   );
 }
@@ -34,9 +78,7 @@ function PostFooter({ postId, tags }) {
 PostFooter.propTypes = {
   tags: PropTypes.arrayOf(PropTypes.string).isRequired,
   postId: PropTypes.string.isRequired,
+  authorId: PropTypes.string.isRequired,
 };
 
 export default PostFooter;
-PostFooter.propTypes = {
-  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
-};

--- a/client/src/components/PostFooter/PostFooter.module.css
+++ b/client/src/components/PostFooter/PostFooter.module.css
@@ -44,3 +44,39 @@
 .footer button:hover {
   border: 1px solid var(--color-dark-grey);
 }
+
+.menuWrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.menuPopover .menuItem {
+  border: none !important;
+  border-radius: 0 !important;
+  background: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+  padding: 0.7em 1.3em;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.18s;
+}
+
+.menuPopover {
+  position: absolute;
+  right: 0;
+  bottom: 2.5rem;
+  min-width: 140px;
+  background: #e1e1e1 !important;
+}
+
+.menuPopover .menuItem:hover {
+  background: #ffe494 !important;
+  border: none !important;
+  border-radius: 0 !important;
+}
+
+.menuWrapper {
+  position: relative;
+  display: inline-block;
+}

--- a/client/src/pages/EditProfile/EditProfile.jsx
+++ b/client/src/pages/EditProfile/EditProfile.jsx
@@ -19,7 +19,12 @@ export default function EditProfile() {
     performFetch: fetchProfile,
     cancelFetch,
   } = useFetchWithAuth(`/user/${username}`, (res) => {
-    setProfile(res.user?.profile || {});
+    setProfile({
+      username: res.user?.username || "",
+      first_name: res.user?.profile?.first_name || "",
+      last_name: res.user?.profile?.last_name || "",
+      bio: res.user?.profile?.bio || "",
+    });
   });
 
   // PATCH profile

--- a/client/src/pages/Post/Post.jsx
+++ b/client/src/pages/Post/Post.jsx
@@ -41,12 +41,13 @@ export default function PostPage() {
       cancelFetchComments();
     };
   }, [id]);
+
   const showFollowBtn = state.userId !== post?.author?._id;
 
   if ((isLoading || isLoadingComments) && (!post || !comments))
     return <div>Loading…</div>;
   if (error || errorComments)
-    return <div>Error: {String(error.message || error)}</div>;
+    return <div>Error: {String(error?.message || error)}</div>;
   if (!post) return null;
 
   return (

--- a/client/src/pages/Profile/Profile.jsx
+++ b/client/src/pages/Profile/Profile.jsx
@@ -1,11 +1,11 @@
 import ProfileDash from "../../components/ProfileDash/ProfileDash.jsx";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import Post from "../../components/Post/Post.jsx";
 import useFetch from "../../hooks/useFetch.js";
-import { useParams } from "react-router-dom";
-import { useContext } from "react";
+import { useParams, useNavigate } from "react-router-dom";
 import StateContext from "../../context/state/StateContext.js";
 import style from "./Profile.module.css";
+import Button from "../../components/Button.jsx";
 
 function Profile() {
   const { username } = useParams();
@@ -16,6 +16,8 @@ function Profile() {
   const { performFetch, error } = useFetch(`/user/${username}`, (response) => {
     setUserData(response.user);
   });
+
+  const navigate = useNavigate();
 
   useEffect(() => {
     const options = {
@@ -34,6 +36,18 @@ function Profile() {
   return (
     <main className={style.main}>
       <ProfileDash size="lg" user={userData} followBtn={!isUser} />
+
+      {isUser && (
+        <div className={style.editProfileBtnWrap}>
+          <Button
+            onClick={() => navigate(`/user/${username}/edit`)}
+            className={style.editProfileBtn}
+          >
+            Edit Profile
+          </Button>
+        </div>
+      )}
+
       <div className={style.postsContainer}>
         {userData &&
         Array.isArray(userData.posts) &&

--- a/client/src/pages/Profile/Profile.module.css
+++ b/client/src/pages/Profile/Profile.module.css
@@ -12,3 +12,27 @@
     padding: 0;
   }
 }
+
+.editProfileBtnWrap {
+  display: flex;
+  justify-content: flex-end;
+  margin: 0.5rem 0 1.5rem 0;
+}
+
+.editProfileBtn {
+  background: #ffcd38;
+  color: #222;
+  font-weight: bold;
+  border-radius: 2rem;
+  border: none;
+  text-decoration: none;
+  padding: 0.6rem 2rem;
+  font-size: 1.1rem;
+  transition: background 0.2s;
+  cursor: pointer;
+  box-shadow: 0 2px 8px #0001;
+}
+
+.editProfileBtn:hover {
+  background: #ffe494;
+}


### PR DESCRIPTION
Summary: 
- Added popover menu (⋯) for post actions, visible only to the post author.
- Implemented “Edit post” actions in the menu
- Implemented  “Delete post” actions in the menu.
- Used custom DeletePostButton for secure post deletion, with redirect to /home after successful delete.

... maybe not the best styling...
<img width="1617" height="738" alt="2025-08-27 19_23_50-Greenshot" src="https://github.com/user-attachments/assets/a70e0158-2ee4-4e22-8287-ae4667f5ddf3" />
