### PR TITLE
follow btn fix

### DIFF
--- a/client/src/hooks/useFollowingStatus.js
+++ b/client/src/hooks/useFollowingStatus.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useContext } from "react";
+import StateContext from "../context/state/StateContext";
 
 const followingStatusMap = new Map();
 const listeners = new Set();
@@ -8,11 +9,15 @@ const notifyListeners = (userId, status) => {
 };
 
 export const useFollowingStatus = (userId) => {
-  const [isFollowing, setIsFollowing] = useState(
-    followingStatusMap.get(userId) || false,
-  );
+  const { state } = useContext(StateContext);
+
+  const [isFollowing, setIsFollowing] = useState(!!state.userId);
 
   useEffect(() => {
+    if (!state.userId) {
+      setIsFollowing(false);
+    }
+
     const listener = (changedUserId, status) => {
       if (changedUserId === userId) {
         setIsFollowing(status);
@@ -21,15 +26,17 @@ export const useFollowingStatus = (userId) => {
 
     listeners.add(listener);
     return () => listeners.delete(listener);
-  }, [userId]);
+  }, [userId, state.userId]);
 
   const updateFollowingStatus = useCallback(
     (newStatus) => {
-      followingStatusMap.set(userId, newStatus);
+      if (!state.userId) return;
+
+      followingStatusMap.set(userId, newStatus); // Записываем, но не используем
       setIsFollowing(newStatus);
       notifyListeners(userId, newStatus);
     },
-    [userId],
+    [userId, state.userId],
   );
 
   return { isFollowing, updateFollowingStatus };

--- a/client/src/hooks/useFollowingStatus.js
+++ b/client/src/hooks/useFollowingStatus.js
@@ -11,7 +11,9 @@ const notifyListeners = (userId, status) => {
 export const useFollowingStatus = (userId) => {
   const { state } = useContext(StateContext);
 
-  const [isFollowing, setIsFollowing] = useState(!!state.userId);
+  const [isFollowing, setIsFollowing] = useState(
+    state.userId ? followingStatusMap.get(userId) || false : false,
+  );
 
   useEffect(() => {
     if (!state.userId) {
@@ -32,7 +34,7 @@ export const useFollowingStatus = (userId) => {
     (newStatus) => {
       if (!state.userId) return;
 
-      followingStatusMap.set(userId, newStatus); // Записываем, но не используем
+      followingStatusMap.set(userId, newStatus);
       setIsFollowing(newStatus);
       notifyListeners(userId, newStatus);
     },

--- a/client/src/hooks/useFollowingStatus.js
+++ b/client/src/hooks/useFollowingStatus.js
@@ -18,6 +18,7 @@ export const useFollowingStatus = (userId) => {
   useEffect(() => {
     if (!state.userId) {
       setIsFollowing(false);
+      followingStatusMap.clear();
     }
 
     const listener = (changedUserId, status) => {


### PR DESCRIPTION
This pull request updates the `useFollowingStatus` hook to integrate with the global authentication state, ensuring that following status is only tracked for authenticated users. The changes improve reliability and prevent unauthorized state updates.

**Integration with authentication state:**

* The hook now uses `StateContext` to access the global authentication state, ensuring that following status is only relevant when a user is logged in.
* The `isFollowing` state is initialized and updated based on the presence of `state.userId`, and automatically resets to `false` when the user logs out.
* The hook’s effect and callback dependencies now include `state.userId` to ensure correct behavior when authentication state changes.
* The `updateFollowingStatus` function prevents updates when there is no authenticated user.